### PR TITLE
Fix Excel 1900 leap year date calculation bug

### DIFF
--- a/src/as_xlsx.pkb
+++ b/src/as_xlsx.pkb
@@ -3987,7 +3987,20 @@ $END
                   then
                     l_one_cell.date_val := date '1904-01-01' + l_nr;
                   else
-                    l_one_cell.date_val := date '1900-03-01' + ( l_nr - case when l_nr < 61 then 60 else 61 end );
+                    -- Fix for Excel 1900 "Leap Year" Bug
+                    if l_nr < 60 then
+                      -- Date is between Jan 1, 1900 and Feb 28, 1900
+                      -- Base date is Dec 31, 1899
+                      l_one_cell.date_val := to_date('31-12-1899','DD-MM-YYYY') + l_nr;
+                    elsif l_nr = 60 then
+                       -- Excel's non-existent "Feb 29, 1900".
+                       -- This date cannot be stored in an Oracle Date type.
+                       l_one_cell.date_val := null;
+                    else
+                       -- Date is Mar 1, 1900 or later
+                       -- Base date is Mar 1, 1900 (Excel Serial 61)
+                       l_one_cell.date_val := to_date('01-03-1900','DD-MM-YYYY') + ( l_nr - 61 );
+                    end if;
                   end if;
                 elsif l_time_styles.exists( r_c.s )
                 then


### PR DESCRIPTION
Microsoft Excel intentionally maintains a legacy Lotus 1-2-3 compatibility bug that incorrectly treats the year 1900 as a leap year. Because the Oracle database engine strictly adheres to the actual Gregorian calendar, importing Excel dates from January and February 1900 previously resulted in a silent one-day offset, corrupting historical data records. Furthermore, encountering Excel's phantom leap day (serial 60) forced an incorrect mapping to March 1, 1900.

Replace the flawed date calculation for the 1900 date system within the `read` function to ensure exact parity between Excel serials and Oracle dates:
- Update the evaluation block to anchor dates prior to serial 60 to December 31, 1899.
- Explicitly nullify the invalid serial 60 to prevent Oracle `DATE` insertion errors.
- Retain the March 1, 1900 anchor for all subsequent dates.